### PR TITLE
Fix dtype conversion in _ensure_float

### DIFF
--- a/nilearn/signal.py
+++ b/nilearn/signal.py
@@ -542,7 +542,7 @@ def high_variance_confounds(
 def _ensure_float(data):
     """Make sure that data is a float type."""
     if data.dtype.kind != "f":
-        if data.dtype.itemsize == "8":
+        if data.dtype.itemsize == 8:
             data = data.astype(np.float64)
         else:
             data = data.astype(np.float32)

--- a/nilearn/tests/test_signal.py
+++ b/nilearn/tests/test_signal.py
@@ -16,6 +16,7 @@ from nilearn.signal import (
     _censor_signals,
     _create_cosine_drift_terms,
     _detrend,
+    _ensure_float,
     _handle_scrubbed_volumes,
     _mean_of_squares,
     butterworth,
@@ -458,6 +459,18 @@ def test_row_sum_of_squares():
     var2 = row_sum_of_squares(signals)
 
     assert_almost_equal(var1, var2)
+
+
+def test_ensure_float_type_conversion():
+    """Check that _ensure_float preserves precision based on itemsize."""
+    arr_int64 = np.arange(5, dtype=np.int64)
+    assert _ensure_float(arr_int64).dtype == np.float64
+
+    arr_int32 = np.arange(5, dtype=np.int32)
+    assert _ensure_float(arr_int32).dtype == np.float32
+
+    arr_float = np.arange(5, dtype=np.float32)
+    assert _ensure_float(arr_float).dtype == np.float32
 
 
 def test_clean_detrending():


### PR DESCRIPTION
## Summary
- fix incorrect `dtype.itemsize` check in `_ensure_float`
- test conversion to float precision in `_ensure_float`

## Testing
- `ruff check nilearn/signal.py nilearn/tests/test_signal.py`
- `pytest -q -o addopts="" nilearn/tests/test_signal.py::test_ensure_float_type_conversion`
- `pytest -q -o addopts="" nilearn/tests/test_init.py::test_version_number`

------
https://chatgpt.com/codex/tasks/task_e_683fb3f025108320acb53d5d8cb223ff